### PR TITLE
README: document the requirements needed for the script to run.

### DIFF
--- a/README
+++ b/README
@@ -18,3 +18,10 @@ Example: perl make-fmv-patch.pl <buildlog> <sourcecode>
     sourcecode: Absolute path to the source file from where patches will be
     generated
 
+------------
+Requirements
+------------
+- Exuberant ctags:
+    In order to use `make-fvm-patch.pl` your system will need Exuberant Ctags
+    (https://sourceforge.net/projects/ctags/), this is due to the `--c-kinds`
+    ctags' flag usage.


### PR DESCRIPTION
Other ctags (such as etags provided by emacs) do not support the flag `--c-kinds`, thus the script may not work as expected on system not providing exuberant ctags.

This pull request documents the needs of the tool to work properly.

Signed-off-by: Simental Magana, Marcos <marcos.simental.magana@intel.com>