### PR TITLE
Add some more C++ extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,13 @@ The repostory makes available a tests directory. Users can use the tests directo
 Once built, follow the steps outlined in the example above:
 
 ```bash
-    perl make-fmv-patch.pl tests/max-build.log tests/
+    perl make-fmv-patch.pl tests/max-test-cpp-build.log tests/
+    perl make-fmv-patch.pl tests/max-test-cxx-build.log tests/
+    perl make-fmv-patch.pl tests/max-test-cc-build.log tests/
+    perl make-fmv-patch.pl tests/max-test-CPP-build.log tests/
+    perl make-fmv-patch.pl tests/max-test-c++-build.log tests/
+    perl make-fmv-patch.pl tests/max-test-cp-build.log tests/
+    perl make-fmv-patch.pl tests/max-test-C-build.log tests/
     perl make-fmv-patch.pl tests/loop-build.log tests/
 ```
 then...

--- a/README.md
+++ b/README.md
@@ -149,9 +149,7 @@ Voila!
 The repostory makes available a tests directory. Users can use the tests directory to conduct their own tests and/or share issues with sample code (for easy reproducability).
 
 ```bash
-    cd tests
-    make
-    cd ..
+    make -C tests
 ```
 
 Once built, follow the steps outlined in the example above:
@@ -171,6 +169,14 @@ then...
 * Recompile the code
 * Run
 
+Or alternatively to test everything at once execute
+```bash
+    make -C tests && \
+    for log in tests/*-build.log; do perl make-fmv-patch.pl "$log"; done && \
+    for patch in tests/*.patch; do patch "${patch%.*}" "$patch"; done && \
+    make -C tests && \
+    for exec in $(find tests -executable \! -type d); do "$exec"; done
+```
 ## License
 
 This project is licensed under an MIT license. See the `LICENSE` file in this project.

--- a/make-fmv-patch.pl
+++ b/make-fmv-patch.pl
@@ -110,12 +110,12 @@ foreach (keys %f) {
     my $fname = $_;
     my @flines = @{$f{$_}->{v_line}};
 
-    if ($fname =~ /(\.c$)/ || $fname =~ /(\.cpp$)/) {
+    if ($fname =~ /(\.c$)/ || $fname =~ /(\.cpp$)|(\.cxx$)|(\.cc$)|(\.CPP$)|(\.c\+\+$)|(\.cp$)|(\.C)/) {
         my $f_path = &find_file($fname);
 
         my @keys = 0;
         my $i = 0;
-        foreach (`ctags --c-kinds=f -x $f_path`) {
+        foreach (`ctags --langmap=C++:.cpp.cxx.cc.CPP.c++.cp.C --c-kinds=f -x $f_path`) {
             chomp $_;
             $keys[$i++] = (split(/\s+/,$_))[2]; # get function number line
         }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,9 +1,16 @@
 all:
 	gcc -O2 -ftree-vectorize loop-test.c -o loop-test -fopt-info-vec &> loop-build.log
-	g++ -O2 -ftree-vectorize max-test.cpp -o max-test -fopt-info-vec &> max-build.log
+	g++ -O2 -ftree-vectorize max-test.cpp -o max-test -fopt-info-vec &> max-test-cpp-build.log
+	g++ -O2 -ftree-vectorize max-test.cxx -o max-test-cxx -fopt-info-vec &> max-test-cxx-build.log
+	g++ -O2 -ftree-vectorize max-test.cc -o max-test-cc -fopt-info-vec &> max-test-cc-build.log
+	g++ -O2 -ftree-vectorize max-test.CPP -o max-test-CPP -fopt-info-vec &> max-test-CPP-build.log
+	g++ -O2 -ftree-vectorize max-test.c++ -o max-test-c++ -fopt-info-vec &> max-test-c++-build.log
+	g++ -O2 -ftree-vectorize max-test.cp -o max-test-cp -fopt-info-vec &> max-test-cp-build.log
+	g++ -O2 -ftree-vectorize max-test.C -o max-test-C -fopt-info-vec &> max-test-C-build.log
 clean:
 	@find . -type f -executable -exec sh -c "file -i '{}' | grep -q 'x-executable; charset=binary'" \; -print | xargs rm -f
 distclean:
 	@rm -rf *.c.patch
 	@rm -rf *.cpp.patch
+	@rm -rf *.cc.patch
 	@rm -rf *build.log

--- a/tests/max-test.C
+++ b/tests/max-test.C
@@ -1,0 +1,36 @@
+#include <iostream>
+using namespace std;
+
+int max(int num1, int num2);
+void foo();
+
+int a[256], b[256];
+
+int main () {
+    foo();
+    return 0;
+}
+
+void foo(){
+
+    int i;
+    for (i=0; i<256; i++){
+        a[i] = 100;
+        b[i] = 200;
+    }
+
+    int ret;
+    for (i=0; i<256; i++){
+       ret = max(a[i], b[i]);
+       cout << "Max value is : " << ret << endl;
+    }
+}
+
+int max(int num1, int num2) {
+    int result;
+    if (num1 > num2)
+        result = num1;
+    else
+        result = num2;
+    return result;
+}

--- a/tests/max-test.CPP
+++ b/tests/max-test.CPP
@@ -1,0 +1,36 @@
+#include <iostream>
+using namespace std;
+
+int max(int num1, int num2);
+void foo();
+
+int a[256], b[256];
+
+int main () {
+    foo();
+    return 0;
+}
+
+void foo(){
+
+    int i;
+    for (i=0; i<256; i++){
+        a[i] = 100;
+        b[i] = 200;
+    }
+
+    int ret;
+    for (i=0; i<256; i++){
+       ret = max(a[i], b[i]);
+       cout << "Max value is : " << ret << endl;
+    }
+}
+
+int max(int num1, int num2) {
+    int result;
+    if (num1 > num2)
+        result = num1;
+    else
+        result = num2;
+    return result;
+}

--- a/tests/max-test.c++
+++ b/tests/max-test.c++
@@ -1,0 +1,36 @@
+#include <iostream>
+using namespace std;
+
+int max(int num1, int num2);
+void foo();
+
+int a[256], b[256];
+
+int main () {
+    foo();
+    return 0;
+}
+
+void foo(){
+
+    int i;
+    for (i=0; i<256; i++){
+        a[i] = 100;
+        b[i] = 200;
+    }
+
+    int ret;
+    for (i=0; i<256; i++){
+       ret = max(a[i], b[i]);
+       cout << "Max value is : " << ret << endl;
+    }
+}
+
+int max(int num1, int num2) {
+    int result;
+    if (num1 > num2)
+        result = num1;
+    else
+        result = num2;
+    return result;
+}

--- a/tests/max-test.cc
+++ b/tests/max-test.cc
@@ -1,0 +1,36 @@
+#include <iostream>
+using namespace std;
+
+int max(int num1, int num2);
+void foo();
+
+int a[256], b[256];
+
+int main () {
+    foo();
+    return 0;
+}
+
+void foo(){
+
+    int i;
+    for (i=0; i<256; i++){
+        a[i] = 100;
+        b[i] = 200;
+    }
+
+    int ret;
+    for (i=0; i<256; i++){
+       ret = max(a[i], b[i]);
+       cout << "Max value is : " << ret << endl;
+    }
+}
+
+int max(int num1, int num2) {
+    int result;
+    if (num1 > num2)
+        result = num1;
+    else
+        result = num2;
+    return result;
+}

--- a/tests/max-test.cp
+++ b/tests/max-test.cp
@@ -1,0 +1,36 @@
+#include <iostream>
+using namespace std;
+
+int max(int num1, int num2);
+void foo();
+
+int a[256], b[256];
+
+int main () {
+    foo();
+    return 0;
+}
+
+void foo(){
+
+    int i;
+    for (i=0; i<256; i++){
+        a[i] = 100;
+        b[i] = 200;
+    }
+
+    int ret;
+    for (i=0; i<256; i++){
+       ret = max(a[i], b[i]);
+       cout << "Max value is : " << ret << endl;
+    }
+}
+
+int max(int num1, int num2) {
+    int result;
+    if (num1 > num2)
+        result = num1;
+    else
+        result = num2;
+    return result;
+}

--- a/tests/max-test.cxx
+++ b/tests/max-test.cxx
@@ -1,0 +1,36 @@
+#include <iostream>
+using namespace std;
+
+int max(int num1, int num2);
+void foo();
+
+int a[256], b[256];
+
+int main () {
+    foo();
+    return 0;
+}
+
+void foo(){
+
+    int i;
+    for (i=0; i<256; i++){
+        a[i] = 100;
+        b[i] = 200;
+    }
+
+    int ret;
+    for (i=0; i<256; i++){
+       ret = max(a[i], b[i]);
+       cout << "Max value is : " << ret << endl;
+    }
+}
+
+int max(int num1, int num2) {
+    int result;
+    if (num1 > num2)
+        result = num1;
+    else
+        result = num2;
+    return result;
+}


### PR DESCRIPTION
[Google C++ style guide](https://google.github.io/styleguide/cppguide.html#File_Names) requires `.cc` extension and also `gcc` supports [few more extensions](https://gcc.gnu.org/onlinedocs/gcc-9.2.0/gcc/Overall-Options.html#Overall-Options) - `.cxx`, `.CPP`, `c++`, `.cp` and `.C`

Also improve the testing instructions in the README.md

