### PR TITLE
Make target-conf emit single line

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,15 +77,7 @@ The command generates the following example.c.patch patch:
          int i,x;
 ```
 
-If you want to use a different target for your code you can create a file targets.conf
-
-For example
-
-```
-#if defined(i386__) || defined(__i386__) || defined(_M_IX86) || defined(_M_IX86) || defined(__X86__) || defined(_X86_) || defined(__I86__) || defined(__INTEL__) || defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64) || defined(_M_AMD64)
-        __attribute__((target_clones("avx2","arch=haswell","default")))
-#endif
-```
+If you want to use a different target for your code you can create a file `targets.conf`. See `targets.conf.txt` for an example.
 
 ### 3. Apply the patch
 Using the example.c.patch file, apply the patch to example.c:

--- a/targets.conf.txt
+++ b/targets.conf.txt
@@ -1,3 +1,5 @@
-#if defined(i386__) || defined(__i386__) || defined(_M_IX86) || defined(_M_IX86) || defined(__X86__) || defined(_X86_) || defined(__I86__) || defined(__INTEL__) || defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64) || defined(_M_AMD64)
-        __attribute__((target_clones("avx2","arch=haswell","default")))
+#if defined(__i386__) || defined(__x86_64__)
+    #define FMV_CLONE_TARGETS "avx2","arch=haswell",
+#else
+    #define FMV_CLONE_TARGETS
 #endif


### PR DESCRIPTION
target.conf currently causes three lines to be emitted. With some
preprocessor defines we can make it just one, plus header.

Also tone down the example arch check. We know we are using GCC & Clang, not Borland whatever.

TODO: change readme examples